### PR TITLE
docs: note Cloudflare Pages deployment trigger

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
+The production docs site ([https://ethosagent.ai](https://ethosagent.ai)) is served via Cloudflare Pages. Deploys are triggered automatically by commits landing on `main` — no manual deploy step is needed.
+
+The commands below are the Docusaurus defaults for GitHub Pages hosting and are not used for production.
+
 Using SSH:
 
 ```bash


### PR DESCRIPTION
Trivial docs note: records in `docs/README.md` that the production docs site (https://ethosagent.ai) is served via Cloudflare Pages and that deploys are triggered by commits landing on `main`. Merging this puts a fresh commit on `main` to trigger the Cloudflare Pages deploy of the redesigned landing page — commit d5e6623 is already on `main` but predates the Pages hookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)